### PR TITLE
Final pipeline tweaks post-going-public

### DIFF
--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -76,10 +76,10 @@ jobs:
         run: dotnet restore ./HeterogeneousCollections/HeterogeneousCollections.fsproj
       - name: Run analyzers
         run: dotnet fsharp-analyzers --project ./HeterogeneousCollections/HeterogeneousCollections.fsproj --analyzers-path ./.analyzerpackages/g-research.fsharp.analyzers/*/ --verbosity detailed --report ./analysis.sarif --treat-as-error GRA-STRING-001 GRA-STRING-002 GRA-STRING-003 GRA-UNIONCASE-001 GRA-INTERPOLATED-001 GRA-TYPE-ANNOTATE-001 GRA-VIRTUALCALL-001 GRA-IMMUTABLECOLLECTIONEQUALITY-001 GRA-JSONOPTS-001 GRA-LOGARGFUNCFULLAPP-001 GRA-DISPBEFOREASYNC-001 --exclude-analyzers PartialAppAnalyzer
-        # - name: Upload SARIF file
-        #   uses: github/codeql-action/upload-sarif@v3
-        #   with:
-        #     sarif_file: analysis.sarif
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: analysis.sarif
 
   nuget-pack:
     runs-on: ubuntu-latest
@@ -134,12 +134,11 @@ jobs:
       - run: echo "All required checks complete."
 
   # This does not gate release, because external dependencies may be flaky.
-  # Disabled while the repo is private
-  # markdown-link-check:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - uses: gaurav-nelson/github-action-markdown-link-check@v1
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
 
   nuget-publish:
     runs-on: ubuntu-latest
@@ -152,7 +151,7 @@ jobs:
         with:
           name: nuget-package
       - name: Publish to NuGet
-        run: dotnet nuget push "HeterogeneousCollections.*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push "HeterogeneousCollections.*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 
   github-tag-and-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/tag.sh
+++ b/.github/workflows/tag.sh
@@ -13,7 +13,7 @@ export -f run_or_echo
 find . -maxdepth 2 -type f -name '*.nupkg' -exec bash -c 'tag=$(basename "$1" .nupkg); git tag "$tag"; run_or_echo git push origin "$tag"' shell {} \;
 
 export TAG
-TAG=$(find . -maxdepth 2 -type f -name 'ShapeSifter.*.nupkg' -exec sh -c 'basename "$1" .nupkg' shell {} \;)
+TAG=$(find . -maxdepth 2 -type f -name 'HeterogeousCollections.*.nupkg' -exec sh -c 'basename "$1" .nupkg' shell {} \;)
 
 case "$TAG" in
   *"
@@ -82,7 +82,7 @@ EOF
 if [[ "$DRY_RUN" = "1" ]]; then
     test_process_curl_error
 else
-    if curl --fail-with-body -L -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GITHUB_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/G-Research/ShapeSifter/releases -d "$curl_body" > curl_output.json ; then
+    if curl --fail-with-body -L -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GITHUB_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/G-Research/HeterogeousCollections/releases -d "$curl_body" > curl_output.json ; then
         cat curl_output.json
         echo "cURL succeeded."
     else

--- a/.github/workflows/tag.sh
+++ b/.github/workflows/tag.sh
@@ -13,7 +13,7 @@ export -f run_or_echo
 find . -maxdepth 2 -type f -name '*.nupkg' -exec bash -c 'tag=$(basename "$1" .nupkg); git tag "$tag"; run_or_echo git push origin "$tag"' shell {} \;
 
 export TAG
-TAG=$(find . -maxdepth 2 -type f -name 'HeterogenousCollections.*.nupkg' -exec sh -c 'basename "$1" .nupkg' shell {} \;)
+TAG=$(find . -maxdepth 2 -type f -name 'HeterogeneousCollections.*.nupkg' -exec sh -c 'basename "$1" .nupkg' shell {} \;)
 
 case "$TAG" in
   *"

--- a/.github/workflows/tag.sh
+++ b/.github/workflows/tag.sh
@@ -13,7 +13,7 @@ export -f run_or_echo
 find . -maxdepth 2 -type f -name '*.nupkg' -exec bash -c 'tag=$(basename "$1" .nupkg); git tag "$tag"; run_or_echo git push origin "$tag"' shell {} \;
 
 export TAG
-TAG=$(find . -maxdepth 2 -type f -name 'HeterogeousCollections.*.nupkg' -exec sh -c 'basename "$1" .nupkg' shell {} \;)
+TAG=$(find . -maxdepth 2 -type f -name 'HeterogenousCollections.*.nupkg' -exec sh -c 'basename "$1" .nupkg' shell {} \;)
 
 case "$TAG" in
   *"

--- a/.github/workflows/tag.sh
+++ b/.github/workflows/tag.sh
@@ -13,7 +13,7 @@ export -f run_or_echo
 find . -maxdepth 2 -type f -name '*.nupkg' -exec bash -c 'tag=$(basename "$1" .nupkg); git tag "$tag"; run_or_echo git push origin "$tag"' shell {} \;
 
 export TAG
-TAG=$(find . -maxdepth 2 -type f -name 'HeterogeneousCollections.*.nupkg' -exec sh -c 'basename "$1" .nupkg' shell {} \;)
+TAG=$(find . -maxdepth 2 -type f -name 'ShapeSifter.*.nupkg' -exec sh -c 'basename "$1" .nupkg' shell {} \;)
 
 case "$TAG" in
   *"
@@ -28,4 +28,65 @@ case "$TAG" in
 esac
 
 # the empty target_commitish indicates the repo default branch
-run_or_echo curl -L -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GITHUB_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/G-Research/HeterogeneousCollections/releases -d '{"tag_name":"'"$TAG"'","target_commitish":"","name":"'"$TAG"'","draft":false,"prerelease":false,"generate_release_notes":false}'
+curl_body='{"tag_name":"'"$TAG"'","target_commitish":"","name":"'"$TAG"'","draft":false,"prerelease":false,"generate_release_notes":false}'
+
+# process_curl_error expects no arguments, but reads the output of `curl` from the file `curl_output.json`.
+script_exit_code=-1
+process_curl_error() {
+    jq_query='if .errors | length == 1 then .errors[0].code else null end'
+    if ! jq -r --exit-status "$jq_query" curl_output.json; then
+        echo "Unexpectedly got number of errors not equal to 1"
+        cat curl_output.json
+        script_exit_code=3
+    else
+        github_error="$(jq -r "$jq_query" curl_output.json)"
+        echo "Error reported by GitHub: $github_error"
+
+        if [ "$github_error" != "already_exists" ]; then
+            echo "Unrecognised error message"
+            script_exit_code=4
+        else
+            # Expected: we tried to make a release that already exists, which can happen when path filters prevent a new tag
+            script_exit_code=0
+        fi
+    fi
+}
+
+test_process_curl_error() {
+    echo "Running tests."
+
+    failed_output=$(cat <<'EOF'
+{
+  "message": "Validation Failed",
+  "errors": [
+    {
+      "resource": "Release",
+      "code": "already_exists",
+      "field": "tag_name"
+    }
+  ],
+  "documentation_url": "https://docs.github.com/rest/releases/releases#create-a-release"
+}
+EOF
+)
+    echo "$failed_output" > curl_output.json
+    process_curl_error
+    if [ $script_exit_code != 0 ] ; then
+        echo "Test failure: got exit code $script_exit_code when we expected 0"
+        exit $script_exit_code
+    fi
+
+    echo "Tests completed."
+}
+
+if [[ "$DRY_RUN" = "1" ]]; then
+    test_process_curl_error
+else
+    if curl --fail-with-body -L -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GITHUB_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/G-Research/ShapeSifter/releases -d "$curl_body" > curl_output.json ; then
+        cat curl_output.json
+        echo "cURL succeeded."
+    else
+        process_curl_error
+        exit $script_exit_code
+    fi
+fi

--- a/HeterogeneousCollections/version.json
+++ b/HeterogeneousCollections/version.json
@@ -2,5 +2,17 @@
   "version": "1.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
+  ],
+  "pathFilters": [
+    ":/",
+    ":^HeterogeneousCollections.Test/",
+    ":^/.github/",
+    ":^/.config/",
+    ":^/hooks/",
+    ":^/analyzers/",
+    ":^/.editorconfig",
+    ":^/CONTRIBUTING.md",
+    ":^.git-blame-ignore-revs",
+    ":^.gitignore"
   ]
 }


### PR DESCRIPTION
Two changes in one here, because I didn't want to churn the repo too much.

* Unblock the two pipeline stages which were disabled while the repo was private
* Add path filters to the library so that we don't cut a release when irrelevant files change. (This requires `dotnet nuget push --skip-duplicate` so that the pipeline succeeds when an irrelevant release would be made, and I've also done the same adjustment from [ShapeSifter](https://github.com/G-Research/ShapeSifter/blob/71a4e2bdf877d74e0bdcbc62fb30bc682c52b40f/.github/workflows/tag.sh) to the tagging workflow.)