### PR TITLE
Bump SDK and stop testing net6

### DIFF
--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -20,11 +20,7 @@ jobs:
           - macOS-latest
           - windows-latest
         dotnet:
-          - { sdk: 6.0.x, framework: net6.0 }
           - { sdk: 8.0.x, framework: net8.0 }
-        include:
-          - os: windows-latest
-            dotnet: { sdk: 6.0.x, framework: net481 }
 
     runs-on: ${{matrix.os}}
 
@@ -48,10 +44,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup .NET SDK v6.0.x
+      - name: Setup .NET SDK v8.0.x
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
       - name: Prepare .NET tools
         run: dotnet tool restore
       - name: Run Fantomas
@@ -64,10 +60,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Setup .NET SDK v6.0.x
+      - name: Setup .NET SDK v8.0.x
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
       - name: Prepare .NET tools
         run: dotnet tool restore
       - name: Prepare analyzers
@@ -88,10 +84,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # so that NerdBank.GitVersioning has access to history
-      - name: Setup .NET SDK v6.0.x
+      - name: Setup .NET SDK v8.0.x
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
       - name: Build
         run: dotnet build HeterogeneousCollections/HeterogeneousCollections.fsproj --configuration Release
       - name: Pack

--- a/HeterogeneousCollections.Test/HeterogeneousCollections.Test.fsproj
+++ b/HeterogeneousCollections.Test/HeterogeneousCollections.Test.fsproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
@@ -21,10 +21,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ApiSurface" Version="4.0.40" />
+    <PackageReference Include="ApiSurface" Version="4.0.44" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NUnit" Version="4.1.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="FsUnit" Version="6.0.0" />
   </ItemGroup>
 

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.400",
+    "rollForward": "latestMajor"
+  }
+}


### PR DESCRIPTION
I did this assuming that https://github.com/dotnet/fsharp/pull/16857 would change our API surfaces, but in this case it has not! The bump should do no harm anyway.