### PR TITLE
security: pin GitHub Actions references to commit SHAs

### DIFF
--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -25,11 +25,11 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
         fetch-depth: 0 # so that NerdBank.GitVersioning has access to history
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
       with:
         dotnet-version: ${{matrix.dotnet.sdk}}
     - name: Restore dependencies
@@ -43,9 +43,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Setup .NET SDK v8.0.x
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
         with:
           dotnet-version: 8.0.x
       - name: Prepare .NET tools
@@ -57,11 +57,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
       - name: Setup .NET SDK v8.0.x
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
         with:
           dotnet-version: 8.0.x
       - name: Prepare .NET tools
@@ -73,7 +73,7 @@ jobs:
       - name: Run analyzers
         run: dotnet fsharp-analyzers --project ./HeterogeneousCollections/HeterogeneousCollections.fsproj --analyzers-path ./.analyzerpackages/g-research.fsharp.analyzers/*/ --verbosity detailed --report ./analysis.sarif --treat-as-error GRA-STRING-001 GRA-STRING-002 GRA-STRING-003 GRA-UNIONCASE-001 GRA-INTERPOLATED-001 GRA-TYPE-ANNOTATE-001 GRA-VIRTUALCALL-001 GRA-IMMUTABLECOLLECTIONEQUALITY-001 GRA-JSONOPTS-001 GRA-LOGARGFUNCFULLAPP-001 GRA-DISPBEFOREASYNC-001 --exclude-analyzers PartialAppAnalyzer
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa
         with:
           sarif_file: analysis.sarif
 
@@ -81,11 +81,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0 # so that NerdBank.GitVersioning has access to history
       - name: Setup .NET SDK v8.0.x
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
         with:
           dotnet-version: 8.0.x
       - name: Build
@@ -93,7 +93,7 @@ jobs:
       - name: Pack
         run: dotnet pack HeterogeneousCollections/HeterogeneousCollections.fsproj --configuration Release
       - name: Upload NuGet artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: nuget-package
           path: HeterogeneousCollections/bin/Release/HeterogeneousCollections.*.nupkg
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download NuGet artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: nuget-package
       - name: Check NuGet contents
@@ -114,9 +114,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [expected-pack]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Download NuGet artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       - name: Tag and release packages
         env:
           GITHUB_TOKEN: "mock-token"
@@ -128,7 +128,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: G-Research/common-actions/check-required-lite@main
+      - uses: G-Research/common-actions/check-required-lite@19d7281a0f9f83e13c78f99a610dbc80fc59ba3b
         with:
           needs-context: ${{ toJSON(needs) }}
 
@@ -136,8 +136,8 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+    - uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368
 
   nuget-publish:
     runs-on: ubuntu-latest
@@ -150,7 +150,7 @@ jobs:
       contents: read
     steps:
       - name: Download NuGet artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: nuget-package
           path: downloaded
@@ -161,7 +161,7 @@ jobs:
         with:
             user: ${{ secrets.NUGET_USER }}
       - name: Publish NuGet package
-        uses: G-Research/common-actions/publish-nuget@main
+        uses: G-Research/common-actions/publish-nuget@19d7281a0f9f83e13c78f99a610dbc80fc59ba3b
         with:
           package-name: HeterogeneousCollections
           nuget-key: ${{ steps.login.outputs.NUGET_API_KEY }}
@@ -175,15 +175,15 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           token: ${{ steps.app-token.outputs.token }}
       - name: Download NuGet artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       - name: Tag and release packages
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

Pins all GitHub Actions references in this repo to 40-character commit SHAs, replacing tag and branch references. This is a supply-chain hardening change with no expected functional impact — every SHA was resolved from its current tag/branch at audit time (2026-05-27).

## Why

Tag-pinned actions can be silently compromised if the upstream tag is rotated to a malicious commit. Branch-pinned actions (e.g. `@main`, `@release/v1`, `@stable`) are even riskier — anyone with push access upstream can change what runs in CI.

GitHub's own recommendation: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

## Notes

- Branch-pinned refs (`@main`, `@release/v1`, `@stable`) were resolved to the branch HEAD at audit time — re-verify before merge if the upstream branch has moved since.
- Part of an org-wide audit covering 26 G-Research repos. The full pinning plan and resolved SHAs are tracked in a local audit project.
- No functional change is expected; CI should pass identically.